### PR TITLE
Ensure that crc32 is type-stable

### DIFF
--- a/src/CRC32.jl
+++ b/src/CRC32.jl
@@ -22,13 +22,13 @@ end
 
 const table = maketable(0xedb88320)
 
-function crc32(data::Vector{UInt8}, crc::Integer=0)
-	crc = ~@compat UInt32(crc)
+function crc32(data::Vector{UInt8}, crc::UInt32=@compat(UInt32(0)))
 	for b in data
 		crc = table[(@compat UInt8(crc&0xff) $ b) + 1] $ (crc >> 8)
 	end
 	~crc
 end
+crc32(data, crc::Integer) = crc32(data, @compat UInt32(crc))
 
 crc32(data::String, crc::Integer=0) = crc32(convert(Vector{UInt8}, data), crc)
 


### PR DESCRIPTION
This ensures that `crc` doesn't change type partway through `crc32`. This makes the algorithm faster:

```
using CRC32
a = rand(0x00:0xff, 10^6)
```

On master:

```
julia> @time crc32(a, 0)
  0.027161 seconds (1.00 M allocations: 15.259 MB, 36.89% gc time)
0x5353a110
```

This PR:

```
julia> @time crc32(a, 0)
  0.005929 seconds (5 allocations: 176 bytes)
0xad521b88
```
