### PR TITLE
update links to alternative packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 See http://en.wikipedia.org/wiki/Cyclic_redundancy_check for more information.
 
 **This package is deprecated.** Please use the CRC32 implementation in any of the following libraries:
-- [Zlib.jl](https://github.com/dcjones/Zlib.jl) -- depends on zlib but about 26x faster
-- [CRC.jl](https://github.com/andrewcooke/CRC.jl) -- written in pure Julia and is comparable in speed to Zlib.jl
+- [CRC32.jl](https://github.com/JuliaIO/CRC32.jl) -- interface to the optimized CRC-32 implementation in Zlib
+- [CRC.jl](https://github.com/andrewcooke/CRC.jl) -- written in pure Julia, supports many CRC variants, and is comparable in speed to zlib
+- [CRC32c standard library](https://docs.julialang.org/en/v1/stdlib/CRC32c/) -- highly optimized implementation of the closely related CRC-32c checksum
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See http://en.wikipedia.org/wiki/Cyclic_redundancy_check for more information.
 
 **This package is deprecated.** Please use the CRC32 implementation in any of the following libraries:
 - [CRC32.jl](https://github.com/JuliaIO/CRC32.jl) -- interface to the optimized CRC-32 implementation in Zlib
-- [CRC.jl](https://github.com/andrewcooke/CRC.jl) -- written in pure Julia, supports many CRC variants, and is comparable in speed to zlib
+- [CRC.jl](https://github.com/andrewcooke/CRC.jl) -- written in pure Julia, supports many CRC variants
 - [CRC32c standard library](https://docs.julialang.org/en/v1/stdlib/CRC32c/) -- highly optimized implementation of the closely related CRC-32c checksum
 
 ## Installation


### PR DESCRIPTION
Zlib.jl was deprecated in favor of [Libz.jl](https://github.com/BioJulia/Libz.jl), which was deprecated in favor of [CodecZlib.jl](https://github.com/JuliaIO/CodecZlib.jl), but CodecZlib.jl doesn't expose a `crc32` API.

To rectify this, I just created a package that exposes the `crc32` function from Zlib — https://github.com/JuliaIO/CRC32.jl — which should hopefully be registered soon (https://github.com/JuliaRegistries/General/pull/75000).

It also seemed good to mention the relationship to the [CRC32c standard library](https://docs.julialang.org/en/v1/stdlib/CRC32c/), which is why I added that too, though it is a slightly different checksum.

Note also that CRC.jl is no longer comparable in performance to Zlib (see benchmarks in https://github.com/andrewcooke/CRC.jl/pull/22), so I removed that claim.